### PR TITLE
Improve ranking formula to center on Perl

### DIFF
--- a/app/lib/GMC/Cron/Update.pm
+++ b/app/lib/GMC/Cron/Update.pm
@@ -73,10 +73,15 @@ sub update_repos {
 
     my $rank = $user->{github_data}{followers};
 
-    my %languages = ();
+    my %languages;
     foreach my $repo (@$repos) {
         $repo->{_user_id} = $user->{_id};
-        $languages{ $repo->{language} }++ if $repo->{language};
+        next unless $repo->{language};
+        $languages{ $repo->{language} }++;
+
+        # Count only Perl projects
+        next unless $repo->{language} eq 'Perl';
+        $rank++;
         $rank += $repo->{watchers};
         $rank += $repo->{forks};
     }


### PR DESCRIPTION
See issue #2.
Changes in the formula to make the ranking more relevant about the Perl community:
- watchers on non-Perl repos are now ignored
- forks on non-Perl repos are now ignored
- Perl projects are counted as 1
