### PR TITLE
Added explicit instructions to the About page on how to "sign up"

### DIFF
--- a/app/templates/root/about.html.ep
+++ b/app/templates/root/about.html.ep
@@ -16,5 +16,14 @@
 + (sum of forks of all of your repositories)
 = rank</pre>
     <p>Currently there are <%= $count %> users listed.</p>
+    <p>To appear on this list, you need to:</p>
+    <ul>
+    <li>Have an account on <a href="https://metacpan.org">MetaCPAN</a>.
+    <li>Have an account on <a href="https://github.com">Github</a>.
+    <li>Edit your <a href="https://metacpan.org/account/profile">MetaCPAN profile</a>.
+        At the bottom you'll find a <strong>Profiles</strong> section.
+        Select GitHub from the drop-down menu and put your github username in the text box that appears.
+        Click on the <em>check</em> link to the right to make sure you got that right.
+    </ul>
 </div>
 


### PR DESCRIPTION
I couldn't work out how to appear on github-meets-cpan, as I'd already linked my github account with MetaCPAN. I raised a MetaCPAN ticket, and I was gently pointed in the right direction.

So I've added some explicit instructions to the about page, to help other people as dozy as me :-)
